### PR TITLE
Linear interpolation of the delay

### DIFF
--- a/brainstate/mixin.py
+++ b/brainstate/mixin.py
@@ -68,7 +68,7 @@ class DelayedInit(Mixin):
   Note this Mixin can be applied in any Python object.
   """
 
-  non_hash_params: Optional[Sequence[str]] = None
+  non_hashable_params: Optional[Sequence[str]] = None
 
   @classmethod
   def delayed(cls, *args, **kwargs) -> 'DelayedInitializer':
@@ -94,7 +94,7 @@ class DelayedInitializer(metaclass=NoSubclassMeta):
   """
 
   def __init__(self, cls: T, *desc_tuple, **desc_dict):
-    self.cls = cls
+    self.cls: type = cls
 
     # arguments
     self.args = desc_tuple

--- a/examples/hh_neuron_model.py
+++ b/examples/hh_neuron_model.py
@@ -17,6 +17,7 @@ import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 
+import brainunit as bu
 import brainstate as bst
 
 bst.environ.set(dt=0.01)
@@ -40,8 +41,7 @@ class HHWithEuler(bst.Dynamics):
     self.V_th = V_th
 
   # m channel
-  # m_alpha = lambda self, V: 0.1 * (V + 40) / (1 - bm.exp(-(V + 40) / 10))
-  m_alpha = lambda self, V: 1. / bst.math.exprel(-(V + 40) / 10)
+  m_alpha = lambda self, V: 1. / bu.math.exprel(-(V + 40) / 10)
   m_beta = lambda self, V: 4.0 * jnp.exp(-(V + 65) / 18)
   m_inf = lambda self, V: self.m_alpha(V) / (self.m_alpha(V) + self.m_beta(V))
   dm = lambda self, m, t, V: self.m_alpha(V) * (1 - m) - self.m_beta(V) * m
@@ -53,8 +53,7 @@ class HHWithEuler(bst.Dynamics):
   dh = lambda self, h, t, V: self.h_alpha(V) * (1 - h) - self.h_beta(V) * h
 
   # n channel
-  # n_alpha = lambda self, V: 0.01 * (V + 55) / (1 - bm.exp(-(V + 55) / 10))
-  n_alpha = lambda self, V: 0.1 / bst.math.exprel(-(V + 55) / 10)
+  n_alpha = lambda self, V: 0.1 / bu.math.exprel(-(V + 55) / 10)
   n_beta = lambda self, V: 0.125 * jnp.exp(-(V + 65) / 80)
   n_inf = lambda self, V: self.n_alpha(V) / (self.n_alpha(V) + self.n_beta(V))
   dn = lambda self, n, t, V: self.n_alpha(V) * (1 - n) - self.n_beta(V) * n

--- a/setup.py
+++ b/setup.py
@@ -66,13 +66,9 @@ setup(
     "Source Code": "https://github.com/brainpy/brainstate",
   },
   extras_require={
-    'cpu': ['jaxlib', 'brainpylib'],
-    'cuda11': ['jaxlib[cuda11_pip]', 'brainpylib'],
-    'cuda12': ['jaxlib[cuda12_pip]', 'brainpylib'],
+    'cpu': ['jaxlib'],
+    'cuda12': ['jaxlib[cuda12_pip]'],
     'tpu': ['jaxlib[tpu]'],
-    'cpu_mini': ['jaxlib'],
-    'cuda11_mini': ['jaxlib[cuda11_pip]'],
-    'cuda12_mini': ['jaxlib[cuda12_pip]'],
   },
   keywords=('computational neuroscience, '
             'brain-inspired computation, '


### PR DESCRIPTION
Previously the delay could only retrieve the data at the exact integer time index. For instance 

```python

brainstate.Delay.retrieve_at_step(0)

brainstate.Delay.retrieve_at_step(1)

```

Now, delay can support to retrieve the data at the time point that is not the time to store the sample. 


```python

# dt = 0.1, 


brainstate.Delay.retrieve_at_time(1.1)  # previously, only the integer time of ``dt``

brainstate.Delay.retrieve_at_time(1.01)  # currently, any time


```


